### PR TITLE
[codex] Refactor macOS dashboard UI

### DIFF
--- a/Sources/App/ContentView.swift
+++ b/Sources/App/ContentView.swift
@@ -8,266 +8,278 @@ struct ContentView: View {
     @State private var email: String = ""
     @State private var password: String = ""
 
-    private var summaryColumns: [GridItem] {
-        [GridItem(.flexible()), GridItem(.flexible())]
-    }
-
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 12) {
-                header
+            VStack(alignment: .leading, spacing: 14) {
+                heroBanner
 
                 if let errorMessage = appState.errorMessage {
-                    Label(errorMessage, systemImage: "exclamationmark.triangle")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                    errorPanel(message: errorMessage)
                 }
 
-                summaryGrid
-                statusGrid
-                authSection
-                helperSection
-                backgroundServiceSection
-                roomsSection
-                actionsSection
-                footer
+                snapshotOverviewPanel
+
+                CredentialsPanel(
+                    title: "Authentication",
+                    subtitle: "Store SMU credentials locally in the Keychain before refreshing.",
+                    email: $email,
+                    password: $password,
+                    onSave: saveCredentials,
+                    onClear: clearCredentials
+                )
+
+                HelperControlsPanel(
+                    currentMode: appState.helperMode,
+                    currentDescription: appState.helperModeDescription,
+                    onStart: appState.startHelper(mode:),
+                    onStop: appState.stopHelper
+                )
+
+                BackgroundServicePanel(
+                    status: appState.launchAgentStatus,
+                    summary: appState.launchAgentDescription,
+                    showsPaths: false,
+                    onInstall: appState.installBackgroundService,
+                    onStart: appState.startBackgroundService,
+                    onStop: appState.stopBackgroundService,
+                    onRemove: appState.uninstallBackgroundService
+                )
+
+                roomsPanel
+                actionsPanel
+                runtimePanel
             }
-            .padding(14)
+            .padding(16)
         }
-        .frame(width: 430, height: 560)
+        .background {
+            SagasuScreenBackground()
+        }
+        .frame(width: 460, height: 620)
     }
 
-    private var header: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text("Sagasu 5")
-                .font(.title3.weight(.semibold))
-            Text("Local desktop client backed by the native helper service.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
+    private var heroBanner: some View {
+        SagasuHeroBanner(
+            eyebrow: "Menu Bar Console",
+            title: "Sagasu 5",
+            subtitle: "Native helper snapshots, credentials, and refresh controls stay one click away.",
+            systemImage: "sparkles.rectangle.stack"
+        ) {
+            HStack(spacing: 10) {
+                heroPill(
+                    title: "Free now",
+                    value: String(appState.rooms?.statistics.available_rooms ?? 0)
+                )
+                heroPill(title: "Refresh", value: appState.formattedLastRefresh)
+                heroPill(title: "Helper", value: appState.helperModeDescription)
+            }
         }
     }
 
-    private var summaryGrid: some View {
-        LazyVGrid(columns: summaryColumns, spacing: 8) {
-            SummaryTile(title: "Free now", value: String(appState.rooms?.statistics.available_rooms ?? 0))
-            SummaryTile(title: "Partial", value: String(appState.rooms?.statistics.partially_available_rooms ?? 0))
-            SummaryTile(title: "Bookings", value: String(appState.bookings?.statistics.total_bookings ?? 0))
-            SummaryTile(title: "Tasks", value: String(appState.tasks?.statistics.total_tasks ?? 0))
-        }
-    }
+    private var snapshotOverviewPanel: some View {
+        SagasuPanel(
+            title: "Local snapshot",
+            subtitle: "A compact view of the helper-owned cache that drives the menu bar status.",
+            systemImage: "chart.bar.xaxis"
+        ) {
+            LazyVGrid(columns: summaryColumns, spacing: 10) {
+                SagasuMetricCard(
+                    title: "Free now",
+                    value: String(appState.rooms?.statistics.available_rooms ?? 0),
+                    detail: "Immediately available rooms",
+                    systemImage: "door.left.hand.open",
+                    tint: .green
+                )
+                SagasuMetricCard(
+                    title: "Partial",
+                    value: String(appState.rooms?.statistics.partially_available_rooms ?? 0),
+                    detail: "Rooms with mixed timeslots",
+                    systemImage: "clock.badge.exclamationmark",
+                    tint: .orange
+                )
+                SagasuMetricCard(
+                    title: "Bookings",
+                    value: String(appState.bookings?.statistics.total_bookings ?? 0),
+                    detail: "Cached booking rows",
+                    systemImage: "calendar",
+                    tint: SagasuTheme.brandSecondary
+                )
+                SagasuMetricCard(
+                    title: "Tasks",
+                    value: String(appState.tasks?.statistics.total_tasks ?? 0),
+                    detail: "Cached task rows",
+                    systemImage: "checklist",
+                    tint: SagasuTheme.brand
+                )
+            }
 
-    private var statusGrid: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text("Service state")
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-
-            ForEach(appState.statuses) { status in
-                HStack {
-                    Text(status.dataset.rawValue.capitalized)
-                        .fontWeight(.medium)
-                    Spacer()
-                    Text(appState.formattedStatus(status))
-                        .foregroundStyle(color(for: status.state))
+            VStack(alignment: .leading, spacing: 10) {
+                ForEach(appState.statuses) { status in
+                    HStack {
+                        Text(status.dataset.rawValue.capitalized)
+                            .font(.subheadline.weight(.semibold))
+                        Spacer(minLength: 0)
+                        SagasuStatusPill(
+                            title: "Status",
+                            value: appState.formattedStatus(status),
+                            tint: SagasuTheme.stateColor(for: status.state)
+                        )
+                    }
                 }
-                .font(.caption)
-                .padding(.horizontal, 10)
-                .padding(.vertical, 8)
-                .background(.quaternary, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
             }
         }
     }
 
-    private var roomsSection: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text("Rooms")
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-
-            if !appState.nextAvailable.isEmpty {
-                RoomLineList(items: appState.nextAvailable)
-            } else if !appState.availableNow.isEmpty {
-                RoomLineList(items: appState.availableNow)
+    private var roomsPanel: some View {
+        SagasuPanel(
+            title: "Room preview",
+            subtitle: "The menu bar window prioritizes what you can use next.",
+            systemImage: "building.2"
+        ) {
+            if preferredRooms.isEmpty {
+                SagasuEmptyStateCard(
+                    title: "Waiting for cached data",
+                    message: "No room availability has been written locally yet.",
+                    systemImage: "building.2.crop.circle"
+                )
             } else {
-                Text("No room availability has been cached locally yet.")
-                    .font(.callout)
+                VStack(spacing: 10) {
+                    ForEach(preferredRooms) { item in
+                        VStack(alignment: .leading, spacing: 6) {
+                            HStack {
+                                Text(item.title)
+                                    .font(.headline)
+                                    .lineLimit(1)
+
+                                Spacer(minLength: 0)
+
+                                Text(item.detail)
+                                    .font(.caption.weight(.semibold))
+                                    .foregroundStyle(.secondary)
+                            }
+
+                            Text(item.context)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+                        .padding(14)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(
+                            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                                .fill(Color.primary.opacity(0.04))
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private var actionsPanel: some View {
+        SagasuPanel(
+            title: "Quick actions",
+            subtitle: "The menu bar stays focused on the highest-frequency controls.",
+            systemImage: "bolt.fill"
+        ) {
+            VStack(alignment: .leading, spacing: 10) {
+                Button(appState.isLoading ? "Refreshing…" : "Refresh Helper Snapshot", action: refreshSnapshot)
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+                    .disabled(appState.isLoading)
+
+                Button("Open Desktop Dashboard", action: openDashboard)
+                    .buttonStyle(.bordered)
+
+                Button("Quit", action: quitApplication)
+                    .buttonStyle(.plain)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    private var runtimePanel: some View {
+        SagasuPanel(
+            title: "Runtime",
+            subtitle: "Quick context for the helper and auth stores backing this desktop client.",
+            systemImage: "info.circle"
+        ) {
+            VStack(alignment: .leading, spacing: 8) {
+                LabeledContent("Last refresh", value: appState.formattedLastRefresh)
+                LabeledContent("Auth store", value: appState.authState.storage_mode.rawValue.capitalized)
+                LabeledContent("Helper mode", value: appState.helperModeDescription)
+                LabeledContent("Launch agent", value: appState.launchAgentDescription)
+
+                Text(appState.authState.runtime)
+                    .font(.caption)
                     .foregroundStyle(.secondary)
             }
         }
     }
 
-    private var authSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Authentication")
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-
-            TextField("SMU email", text: $email)
-                .textFieldStyle(.roundedBorder)
-            SecureField("SMU password", text: $password)
-                .textFieldStyle(.roundedBorder)
-
-            HStack {
-                Button("Save to Keychain") {
-                    appState.saveCredentials(email: email, password: password)
-                    password = ""
-                }
-                .buttonStyle(.borderedProminent)
-
-                Button("Clear") {
-                    appState.clearCredentials()
-                    email = ""
-                    password = ""
-                }
-                .buttonStyle(.bordered)
-            }
-        }
+    private var summaryColumns: [GridItem] {
+        [
+            GridItem(.flexible(), spacing: 10),
+            GridItem(.flexible(), spacing: 10)
+        ]
     }
 
-    private var helperSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Helper control")
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-
-            HStack {
-                ForEach(HelperRunMode.allCases) { mode in
-                    Button(appState.helperMode == mode ? "\(mode.title) running" : "Start \(mode.title)") {
-                        appState.startHelper(mode: mode)
-                    }
-                    .buttonStyle(.bordered)
-                }
-
-                Button("Stop") {
-                    appState.stopHelper()
-                }
-                .buttonStyle(.bordered)
-            }
+    private var preferredRooms: [AppState.RoomLine] {
+        if !appState.nextAvailable.isEmpty {
+            return Array(appState.nextAvailable.prefix(5))
         }
+
+        return Array(appState.availableNow.prefix(5))
     }
 
-    private var backgroundServiceSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Background service")
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
+    @ViewBuilder
+    private func heroPill(title: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title.uppercased())
+                .font(.caption2.weight(.bold))
+                .tracking(0.8)
+                .foregroundStyle(.white.opacity(0.78))
 
-            Text(appState.launchAgentDescription)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-
-            HStack {
-                Button("Install") {
-                    appState.installBackgroundService()
-                }
-                .buttonStyle(.bordered)
-
-                Button("Start") {
-                    appState.startBackgroundService()
-                }
-                .buttonStyle(.bordered)
-
-                Button("Stop") {
-                    appState.stopBackgroundService()
-                }
-                .buttonStyle(.bordered)
-
-                Button("Remove") {
-                    appState.uninstallBackgroundService()
-                }
-                .buttonStyle(.bordered)
-            }
-        }
-    }
-
-    private var actionsSection: some View {
-        VStack(spacing: 8) {
-            Button("Refresh Helper Snapshot") {
-                appState.refresh(manual: true)
-            }
-            .buttonStyle(.borderedProminent)
-            .controlSize(.large)
-            .disabled(appState.isLoading)
-
-            Button("Open Desktop Dashboard") {
-                openWindow(id: "dashboard")
-            }
-            .buttonStyle(.bordered)
-
-            Button("Quit") {
-                NSApplication.shared.terminate(nil)
-            }
-            .buttonStyle(.plain)
-            .frame(maxWidth: .infinity, alignment: .leading)
-        }
-    }
-
-    private var footer: some View {
-        VStack(alignment: .leading, spacing: 3) {
-            Text("Last helper refresh: \(appState.formattedLastRefresh)")
-            Text("Auth store: \(appState.authState.storage_mode.rawValue.capitalized)")
-            Text("Helper mode: \(appState.helperModeDescription)")
-            Text("Launch agent: \(appState.launchAgentDescription)")
-            Text(appState.authState.runtime)
-        }
-        .font(.caption)
-        .foregroundStyle(.secondary)
-    }
-
-    private func color(for state: DatasetState) -> Color {
-        switch state {
-        case .idle: return .secondary
-        case .loading: return .orange
-        case .success: return .green
-        case .stale: return .yellow
-        case .failed: return .red
-        }
-    }
-}
-
-private struct SummaryTile: View {
-    let title: String
-    let value: String
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(title)
-                .font(.caption)
-                .foregroundStyle(.secondary)
             Text(value)
-                .font(.title2.weight(.semibold))
-                .monospacedDigit()
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.white)
+                .lineLimit(1)
         }
-        .padding(10)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.quaternary, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(.white.opacity(0.14), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
     }
-}
 
-private struct RoomLineList: View {
-    let items: [AppState.RoomLine]
-
-    var body: some View {
-        VStack(spacing: 6) {
-            ForEach(items) { item in
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack {
-                        Text(item.title)
-                            .fontWeight(.medium)
-                            .lineLimit(1)
-                        Spacer()
-                        Text(item.detail)
-                            .foregroundStyle(.secondary)
-                    }
-                    Text(item.context)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                }
-                .padding(10)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(.quaternary, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
-            }
+    @ViewBuilder
+    private func errorPanel(message: String) -> some View {
+        SagasuPanel(
+            title: "Helper warning",
+            subtitle: "The local helper reported an issue. Existing cached data is preserved where possible.",
+            systemImage: "exclamationmark.triangle.fill"
+        ) {
+            Text(message)
+                .font(.callout)
         }
+    }
+
+    private func saveCredentials() {
+        appState.saveCredentials(email: email, password: password)
+        password = ""
+    }
+
+    private func clearCredentials() {
+        appState.clearCredentials()
+        email = ""
+        password = ""
+    }
+
+    private func refreshSnapshot() {
+        appState.refresh(manual: true)
+    }
+
+    private func openDashboard() {
+        openWindow(id: "dashboard")
+    }
+
+    private func quitApplication() {
+        NSApplication.shared.terminate(nil)
     }
 }

--- a/Sources/App/DashboardDataPanels.swift
+++ b/Sources/App/DashboardDataPanels.swift
@@ -1,0 +1,374 @@
+import SwiftUI
+import SagasuShared
+
+enum DashboardSelection {
+    case room(ScrapedRoomsResponse.Room)
+    case booking(ScrapedBookingsResponse.Booking)
+    case task(ScrapedTasksResponse.Task)
+}
+
+struct DatasetHealthPanel: View {
+    let statuses: [DatasetStatus]
+    let formattedStatus: (DatasetStatus) -> String
+    let formattedTimestamp: (String?) -> String
+
+    var body: some View {
+        SagasuPanel(
+            title: "Dataset health",
+            subtitle: "Every helper refresh updates the cached rooms, bookings, and tasks payloads independently.",
+            systemImage: "waveform.path.ecg.rectangle"
+        ) {
+            VStack(alignment: .leading, spacing: 12) {
+                ForEach(statuses) { status in
+                    VStack(alignment: .leading, spacing: 10) {
+                        HStack {
+                            Text(status.dataset.rawValue.capitalized)
+                                .font(.headline)
+
+                            Spacer(minLength: 0)
+
+                            SagasuStatusPill(
+                                title: "State",
+                                value: formattedStatus(status),
+                                tint: SagasuTheme.stateColor(for: status.state)
+                            )
+                        }
+
+                        if let message = status.message {
+                            Text(message)
+                                .font(.callout)
+                                .foregroundStyle(.secondary)
+                        }
+
+                        LabeledContent("Last success", value: formattedTimestamp(status.last_success_at))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(14)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(
+                        RoundedRectangle(cornerRadius: 18, style: .continuous)
+                            .fill(SagasuTheme.stateColor(for: status.state).opacity(0.08))
+                    )
+                }
+            }
+        }
+    }
+}
+
+struct DashboardSelectionPanel: View {
+    let selection: DashboardSelection?
+    let formattedTimestamp: (String?) -> String
+
+    var body: some View {
+        SagasuPanel(
+            title: "Selected detail",
+            subtitle: "Pick a room, booking, or task below to inspect the currently cached record.",
+            systemImage: "sidebar.right"
+        ) {
+            Group {
+                if let selection {
+                    switch selection {
+                    case let .room(room):
+                        roomDetail(room)
+                    case let .booking(booking):
+                        bookingDetail(booking)
+                    case let .task(task):
+                        taskDetail(task)
+                    }
+                } else {
+                    SagasuEmptyStateCard(
+                        title: "Nothing selected",
+                        message: "Choose a row from the rooms, bookings, or tasks panels to inspect more detail.",
+                        systemImage: "cursorarrow.click"
+                    )
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func roomDetail(_ room: ScrapedRoomsResponse.Room) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(room.name)
+                        .font(.title3.weight(.semibold))
+
+                    Text("\(room.building) • \(room.floor) • \(room.facility_type)")
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer(minLength: 0)
+
+                SagasuStatusPill(
+                    title: "Availability",
+                    value: room.availability_summary.is_available_now
+                        ? "Free now"
+                        : formattedTimestamp(room.availability_summary.next_available_at),
+                    tint: room.availability_summary.is_available_now ? .green : .orange
+                )
+            }
+
+            ForEach(Array(room.timeslots.prefix(8).enumerated()), id: \.offset) { _, slot in
+                HStack {
+                    Text("\(slot.start) - \(slot.end)")
+                        .font(.system(.caption, design: .monospaced))
+                    Spacer(minLength: 0)
+                    Text(slot.status)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.vertical, 2)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func bookingDetail(_ booking: ScrapedBookingsResponse.Booking) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(booking.room_name)
+                .font(.title3.weight(.semibold))
+
+            detailRow(label: "Window", value: "\(booking.date) • \(booking.start_time)-\(booking.end_time)")
+            detailRow(label: "Booked by", value: booking.booked_by)
+            detailRow(label: "Type", value: booking.booking_type)
+            detailRow(label: "Status", value: booking.status)
+        }
+    }
+
+    @ViewBuilder
+    private func taskDetail(_ task: ScrapedTasksResponse.Task) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(task.task_type)
+                .font(.title3.weight(.semibold))
+
+            detailRow(label: "Room", value: task.room_name)
+            detailRow(label: "Date", value: task.date)
+            detailRow(label: "Requested by", value: task.requested_by)
+            detailRow(label: "Status", value: task.status)
+        }
+    }
+
+    @ViewBuilder
+    private func detailRow(label: String, value: String) -> some View {
+        LabeledContent(label, value: value)
+            .font(.callout)
+    }
+}
+
+struct RoomsPanel: View {
+    let rooms: [ScrapedRoomsResponse.Room]
+    let selectedRoomID: String?
+    let onSelect: (String) -> Void
+    let formattedTimestamp: (String?) -> String
+
+    var body: some View {
+        SagasuPanel(
+            title: "Rooms",
+            subtitle: "The latest locally cached availability records.",
+            systemImage: "door.left.hand.open"
+        ) {
+            if rooms.isEmpty {
+                SagasuEmptyStateCard(
+                    title: "No rooms cached",
+                    message: "Run a refresh after credentials are stored to hydrate the local room snapshot.",
+                    systemImage: "building.2"
+                )
+            } else {
+                VStack(spacing: 10) {
+                    ForEach(rooms.prefix(10)) { room in
+                        SelectableListCard(
+                            isSelected: room.id == selectedRoomID,
+                            action: {
+                                onSelect(room.id)
+                            }
+                        ) {
+                            VStack(alignment: .leading, spacing: 6) {
+                                HStack {
+                                    Text(room.name)
+                                        .font(.headline)
+                                        .lineLimit(1)
+
+                                    Spacer(minLength: 0)
+
+                                    Text(
+                                        room.availability_summary.is_available_now
+                                            ? "Free now"
+                                            : formattedTimestamp(room.availability_summary.next_available_at)
+                                    )
+                                    .font(.caption.weight(.semibold))
+                                    .foregroundStyle(.secondary)
+                                }
+
+                                Text("\(room.building) • \(room.floor) • \(room.facility_type)")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(1)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct BookingsPanel: View {
+    let bookings: [ScrapedBookingsResponse.Booking]
+    let selectedBookingID: String?
+    let onSelect: (String) -> Void
+
+    var body: some View {
+        SagasuPanel(
+            title: "Bookings",
+            subtitle: "Recent booking rows from the cached snapshot.",
+            systemImage: "calendar.badge.clock"
+        ) {
+            if bookings.isEmpty {
+                SagasuEmptyStateCard(
+                    title: "No bookings cached",
+                    message: "Once the helper refreshes successfully, recent booking rows will appear here.",
+                    systemImage: "calendar"
+                )
+            } else {
+                VStack(spacing: 10) {
+                    ForEach(bookings) { booking in
+                        SelectableListCard(
+                            isSelected: booking.id == selectedBookingID,
+                            action: {
+                                onSelect(booking.id)
+                            }
+                        ) {
+                            HStack(alignment: .top) {
+                                VStack(alignment: .leading, spacing: 5) {
+                                    Text(booking.room_name)
+                                        .font(.headline)
+                                    Text("\(booking.date) • \(booking.start_time)-\(booking.end_time)")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+
+                                Spacer(minLength: 0)
+
+                                Text(booking.status)
+                                    .font(.caption.weight(.semibold))
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct TasksPanel: View {
+    let tasks: [ScrapedTasksResponse.Task]
+    let selectedTaskID: String?
+    let onSelect: (String) -> Void
+
+    var body: some View {
+        SagasuPanel(
+            title: "Tasks",
+            subtitle: "Recently cached task activity produced by the helper.",
+            systemImage: "checklist"
+        ) {
+            if tasks.isEmpty {
+                SagasuEmptyStateCard(
+                    title: "No tasks cached",
+                    message: "Task rows will appear once the local helper writes them into the snapshot.",
+                    systemImage: "list.bullet.rectangle"
+                )
+            } else {
+                VStack(spacing: 10) {
+                    ForEach(tasks) { task in
+                        SelectableListCard(
+                            isSelected: task.id == selectedTaskID,
+                            action: {
+                                onSelect(task.id)
+                            }
+                        ) {
+                            HStack(alignment: .top) {
+                                VStack(alignment: .leading, spacing: 5) {
+                                    Text(task.task_type)
+                                        .font(.headline)
+                                    Text("\(task.room_name) • \(task.date)")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+
+                                Spacer(minLength: 0)
+
+                                Text(task.status)
+                                    .font(.caption.weight(.semibold))
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct HelperConsolePanel: View {
+    let console: String
+
+    var body: some View {
+        SagasuPanel(
+            title: "Helper console",
+            subtitle: "Stdout and stderr captured from the most recent helper runs.",
+            systemImage: "terminal"
+        ) {
+            ScrollView {
+                Text(console.isEmpty ? "No helper output recorded yet." : console)
+                    .font(.system(.caption, design: .monospaced))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
+            }
+            .frame(minHeight: 200)
+            .padding(14)
+            .background(
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .fill(Color.black.opacity(0.06))
+            )
+        }
+    }
+}
+
+private struct SelectableListCard<Content: View>: View {
+    let isSelected: Bool
+    let action: () -> Void
+    private let content: Content
+
+    init(
+        isSelected: Bool,
+        action: @escaping () -> Void,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.isSelected = isSelected
+        self.action = action
+        self.content = content()
+    }
+
+    var body: some View {
+        Button(action: action) {
+            content
+                .padding(14)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                        .fill(isSelected ? SagasuTheme.brand.opacity(0.14) : Color.primary.opacity(0.04))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                                .strokeBorder(
+                                    isSelected ? SagasuTheme.brand.opacity(0.32) : Color.primary.opacity(0.06),
+                                    lineWidth: 1
+                                )
+                        }
+                )
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/Sources/App/DesktopDashboardView.swift
+++ b/Sources/App/DesktopDashboardView.swift
@@ -13,378 +13,158 @@ struct DesktopDashboardView: View {
         NavigationStack {
             ScrollView {
                 VStack(alignment: .leading, spacing: 18) {
-                    hero
-                    datasetCards
-                    authPanel
-                    helperPanel
-                    backgroundServicePanel
-                    configPanel
-                    detailPanel
-                    roomsPanel
-                    bookingsPanel
-                    tasksPanel
-                    consolePanel
+                    heroBanner
+
+                    if let errorMessage = appState.errorMessage {
+                        errorPanel(message: errorMessage)
+                    }
+
+                    LazyVGrid(columns: summaryColumns, spacing: 12) {
+                        SagasuMetricCard(
+                            title: "Free now",
+                            value: String(appState.rooms?.statistics.available_rooms ?? 0),
+                            detail: "Immediate room availability",
+                            systemImage: "door.left.hand.open",
+                            tint: .green
+                        )
+                        SagasuMetricCard(
+                            title: "Partial rooms",
+                            value: String(appState.rooms?.statistics.partially_available_rooms ?? 0),
+                            detail: "Rooms with mixed occupancy",
+                            systemImage: "clock.badge.exclamationmark",
+                            tint: .orange
+                        )
+                        SagasuMetricCard(
+                            title: "Bookings",
+                            value: String(appState.bookings?.statistics.total_bookings ?? 0),
+                            detail: "Cached booking records",
+                            systemImage: "calendar",
+                            tint: SagasuTheme.brandSecondary
+                        )
+                        SagasuMetricCard(
+                            title: "Tasks",
+                            value: String(appState.tasks?.statistics.total_tasks ?? 0),
+                            detail: "Cached task records",
+                            systemImage: "checklist",
+                            tint: SagasuTheme.brand
+                        )
+                    }
+
+                    LazyVGrid(columns: dashboardColumns, spacing: 16) {
+                        DatasetHealthPanel(
+                            statuses: appState.statuses,
+                            formattedStatus: appState.formattedStatus,
+                            formattedTimestamp: appState.formattedScrapedAt
+                        )
+
+                        DashboardSelectionPanel(
+                            selection: currentSelection,
+                            formattedTimestamp: appState.formattedScrapedAt
+                        )
+
+                        CredentialsPanel(
+                            title: "Authentication",
+                            subtitle: "Store credentials before running helper refreshes against the source system.",
+                            email: $email,
+                            password: $password,
+                            onSave: saveCredentials,
+                            onClear: clearCredentials
+                        )
+
+                        HelperControlsPanel(
+                            currentMode: appState.helperMode,
+                            currentDescription: appState.helperModeDescription,
+                            onStart: appState.startHelper(mode:),
+                            onStop: appState.stopHelper
+                        )
+
+                        BackgroundServicePanel(
+                            status: appState.launchAgentStatus,
+                            summary: appState.launchAgentDescription,
+                            showsPaths: true,
+                            onInstall: appState.installBackgroundService,
+                            onStart: appState.startBackgroundService,
+                            onStop: appState.stopBackgroundService,
+                            onRemove: appState.uninstallBackgroundService
+                        )
+
+                        ScrapePreferencesPanel(
+                            preferences: scrapePreferencesBinding,
+                            onSave: appState.saveScrapePreferences
+                        )
+
+                        RoomsPanel(
+                            rooms: appState.rooms?.rooms ?? [],
+                            selectedRoomID: selectedRoomID,
+                            onSelect: selectRoom,
+                            formattedTimestamp: appState.formattedScrapedAt
+                        )
+
+                        BookingsPanel(
+                            bookings: appState.recentBookings,
+                            selectedBookingID: selectedBookingID,
+                            onSelect: selectBooking
+                        )
+
+                        TasksPanel(
+                            tasks: appState.recentTasks,
+                            selectedTaskID: selectedTaskID,
+                            onSelect: selectTask
+                        )
+
+                        runtimePanel
+                    }
+
+                    HelperConsolePanel(console: appState.helperConsole)
                 }
-                .padding(20)
+                .padding(24)
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
             .navigationTitle("Sagasu Desktop")
+            .background {
+                SagasuScreenBackground()
+            }
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
-                    Button(appState.isLoading ? "Refreshing…" : "Refresh Now") {
-                        appState.refresh(manual: true)
-                    }
+                    Button(appState.isLoading ? "Refreshing…" : "Refresh Now", action: refreshNow)
                     .disabled(appState.isLoading)
                 }
             }
         }
-        .frame(minWidth: 920, minHeight: 680)
+        .frame(minWidth: 1100, minHeight: 760)
     }
 
-    private var hero: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Native local snapshot")
-                .font(.largeTitle.weight(.bold))
-            Text("The desktop app now reads locally cached room, booking, and task data produced by the helper instead of GitHub-hosted JSON.")
-                .font(.body)
-                .foregroundStyle(.secondary)
-        }
-    }
-
-    private var datasetCards: some View {
-        HStack(spacing: 12) {
-            ForEach(appState.statuses) { status in
-                VStack(alignment: .leading, spacing: 6) {
-                    Text(status.dataset.rawValue.capitalized)
-                        .font(.headline)
-                    Text(appState.formattedStatus(status))
-                        .font(.subheadline.weight(.medium))
-                    if let message = status.message {
-                        Text(message)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(2)
-                    }
-                }
-                .padding(14)
-                .frame(maxWidth: .infinity, minHeight: 96, alignment: .topLeading)
-                .background(.quaternary, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+    private var heroBanner: some View {
+        SagasuHeroBanner(
+            eyebrow: "Desktop Dashboard",
+            title: "Local snapshot control room",
+            subtitle: "Monitor helper health, refine scrape inputs, and inspect cached room, booking, and task data from one desktop surface.",
+            systemImage: "rectangle.3.group.bubble.left.fill"
+        ) {
+            HStack(spacing: 12) {
+                heroPill(title: "Last refresh", value: appState.formattedLastRefresh)
+                heroPill(title: "Auth", value: appState.authState.storage_mode.rawValue.capitalized)
+                heroPill(title: "Launch agent", value: appState.launchAgentDescription)
             }
         }
     }
 
-    private var authPanel: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("Authentication")
-                .font(.title3.weight(.semibold))
-
-            TextField("SMU email", text: $email)
-                .textFieldStyle(.roundedBorder)
-            SecureField("SMU password", text: $password)
-                .textFieldStyle(.roundedBorder)
-
-            HStack {
-                Button("Save to Keychain") {
-                    appState.saveCredentials(email: email, password: password)
-                    password = ""
-                }
-                .buttonStyle(.borderedProminent)
-
-                Button("Clear credentials") {
-                    appState.clearCredentials()
-                    email = ""
-                    password = ""
-                }
-                .buttonStyle(.bordered)
-            }
-        }
-    }
-
-    private var helperPanel: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("Helper control")
-                .font(.title3.weight(.semibold))
-
-            Text("Mode: \(appState.helperModeDescription)")
-                .font(.callout)
-                .foregroundStyle(.secondary)
-
-            HStack {
-                ForEach(HelperRunMode.allCases) { mode in
-                    Button(appState.helperMode == mode ? "\(mode.title) running" : "Start \(mode.title)") {
-                        appState.startHelper(mode: mode)
-                    }
-                    .buttonStyle(.bordered)
-                }
-
-                Button("Stop helper") {
-                    appState.stopHelper()
-                }
-                .buttonStyle(.bordered)
-            }
-        }
-    }
-
-    private var backgroundServicePanel: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("Background service")
-                .font(.title3.weight(.semibold))
-
-            Text(appState.launchAgentDescription)
-                .font(.callout)
-                .foregroundStyle(.secondary)
-
-            if let status = appState.launchAgentStatus {
-                Text("Plist: \(status.plistURL.path)")
-                    .font(.system(.caption, design: .monospaced))
-                    .foregroundStyle(.secondary)
-                Text("Log: \(status.logURL.path)")
-                    .font(.system(.caption, design: .monospaced))
+    private var runtimePanel: some View {
+        SagasuPanel(
+            title: "Runtime",
+            subtitle: "Environment details that shape how the helper and desktop shell are currently operating.",
+            systemImage: "info.circle"
+        ) {
+            VStack(alignment: .leading, spacing: 8) {
+                LabeledContent("Last refresh", value: appState.formattedLastRefresh)
+                LabeledContent("Auth store", value: appState.authState.storage_mode.rawValue.capitalized)
+                LabeledContent("Helper mode", value: appState.helperModeDescription)
+                LabeledContent("Launch agent", value: appState.launchAgentDescription)
+                Text(appState.authState.runtime)
+                    .font(.caption)
                     .foregroundStyle(.secondary)
             }
-
-            HStack {
-                Button("Install agent") {
-                    appState.installBackgroundService()
-                }
-                .buttonStyle(.borderedProminent)
-
-                Button("Start agent") {
-                    appState.startBackgroundService()
-                }
-                .buttonStyle(.bordered)
-
-                Button("Stop agent") {
-                    appState.stopBackgroundService()
-                }
-                .buttonStyle(.bordered)
-
-                Button("Remove agent") {
-                    appState.uninstallBackgroundService()
-                }
-                .buttonStyle(.bordered)
-            }
         }
-    }
-
-    private var configPanel: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("Scrape preferences")
-                .font(.title3.weight(.semibold))
-
-            HStack {
-                TextField("Date or TODAY", text: Binding(
-                    get: { appState.scrapePreferences.date },
-                    set: { appState.scrapePreferences.date = $0 }
-                ))
-                .textFieldStyle(.roundedBorder)
-
-                TextField("Start", text: Binding(
-                    get: { appState.scrapePreferences.start_time },
-                    set: { appState.scrapePreferences.start_time = $0 }
-                ))
-                .textFieldStyle(.roundedBorder)
-
-                TextField("End", text: Binding(
-                    get: { appState.scrapePreferences.end_time },
-                    set: { appState.scrapePreferences.end_time = $0 }
-                ))
-                .textFieldStyle(.roundedBorder)
-
-                TextField("Capacity", text: Binding(
-                    get: { appState.scrapePreferences.capacity },
-                    set: { appState.scrapePreferences.capacity = $0 }
-                ))
-                .textFieldStyle(.roundedBorder)
-            }
-
-            TextField("Buildings (comma-separated)", text: csvBinding(for: \.buildings))
-                .textFieldStyle(.roundedBorder)
-            TextField("Floors (comma-separated)", text: csvBinding(for: \.floors))
-                .textFieldStyle(.roundedBorder)
-            TextField("Facility types (comma-separated)", text: csvBinding(for: \.facility_types))
-                .textFieldStyle(.roundedBorder)
-            TextField("Equipment (comma-separated)", text: csvBinding(for: \.equipment))
-                .textFieldStyle(.roundedBorder)
-
-            Button("Save scrape preferences") {
-                appState.saveScrapePreferences()
-            }
-            .buttonStyle(.borderedProminent)
-        }
-    }
-
-    @ViewBuilder
-    private var detailPanel: some View {
-        if let room = selectedRoom {
-            VStack(alignment: .leading, spacing: 10) {
-                Text("Selected room")
-                    .font(.title3.weight(.semibold))
-                Text(room.name)
-                    .font(.headline)
-                Text("\(room.building) • \(room.floor) • \(room.facility_type)")
-                    .foregroundStyle(.secondary)
-                ForEach(Array(room.timeslots.prefix(12).enumerated()), id: \.offset) { _, slot in
-                    Text("\(slot.start)-\(slot.end) • \(slot.status)")
-                        .font(.system(.caption, design: .monospaced))
-                }
-            }
-        } else if let booking = selectedBooking {
-            VStack(alignment: .leading, spacing: 10) {
-                Text("Selected booking")
-                    .font(.title3.weight(.semibold))
-                Text(booking.room_name)
-                    .font(.headline)
-                Text("\(booking.date) • \(booking.start_time)-\(booking.end_time)")
-                    .foregroundStyle(.secondary)
-                Text("Booked by: \(booking.booked_by)")
-                Text("Type: \(booking.booking_type)")
-                Text("Status: \(booking.status)")
-            }
-        } else if let task = selectedTask {
-            VStack(alignment: .leading, spacing: 10) {
-                Text("Selected task")
-                    .font(.title3.weight(.semibold))
-                Text(task.task_type)
-                    .font(.headline)
-                Text("\(task.room_name) • \(task.date)")
-                    .foregroundStyle(.secondary)
-                Text("Requested by: \(task.requested_by)")
-                Text("Status: \(task.status)")
-            }
-        }
-    }
-
-    private var roomsPanel: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("Rooms")
-                .font(.title3.weight(.semibold))
-
-            if let rooms = appState.rooms?.rooms, !rooms.isEmpty {
-                ForEach(rooms.prefix(12)) { room in
-                    Button {
-                        selectedRoomID = room.id
-                        selectedBookingID = nil
-                        selectedTaskID = nil
-                    } label: {
-                        VStack(alignment: .leading, spacing: 4) {
-                            HStack {
-                                Text(room.name)
-                                    .fontWeight(.medium)
-                                Spacer()
-                                Text(room.availability_summary.is_available_now ? "Free now" : "Next: \(appState.formattedScrapedAt(room.availability_summary.next_available_at))")
-                                    .foregroundStyle(.secondary)
-                            }
-                            Text("\(room.building) • \(room.floor) • \(room.facility_type)")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                        .padding(12)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .background(.quaternary, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-                    }
-                    .buttonStyle(.plain)
-                }
-            } else {
-                emptyState("No locally cached room rows are available yet.")
-            }
-        }
-    }
-
-    private var bookingsPanel: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("Bookings")
-                .font(.title3.weight(.semibold))
-
-            if !appState.recentBookings.isEmpty {
-                ForEach(appState.recentBookings) { booking in
-                    Button {
-                        selectedBookingID = booking.id
-                        selectedRoomID = nil
-                        selectedTaskID = nil
-                    } label: {
-                        HStack {
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text(booking.room_name)
-                                    .fontWeight(.medium)
-                                Text("\(booking.date) • \(booking.start_time)-\(booking.end_time)")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-                            Spacer()
-                            Text(booking.status)
-                                .font(.caption.weight(.medium))
-                        }
-                        .padding(12)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .background(.quaternary, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-                    }
-                    .buttonStyle(.plain)
-                }
-            } else {
-                emptyState("No bookings are cached right now.")
-            }
-        }
-    }
-
-    private var tasksPanel: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("Tasks")
-                .font(.title3.weight(.semibold))
-
-            if !appState.recentTasks.isEmpty {
-                ForEach(appState.recentTasks) { task in
-                    Button {
-                        selectedTaskID = task.id
-                        selectedRoomID = nil
-                        selectedBookingID = nil
-                    } label: {
-                        HStack {
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text(task.task_type)
-                                    .fontWeight(.medium)
-                                Text("\(task.room_name) • \(task.date)")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-                            Spacer()
-                            Text(task.status)
-                                .font(.caption.weight(.medium))
-                        }
-                        .padding(12)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .background(.quaternary, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-                    }
-                    .buttonStyle(.plain)
-                }
-            } else {
-                emptyState("No task rows are cached right now.")
-            }
-        }
-    }
-
-    private var consolePanel: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("Helper console")
-                .font(.title3.weight(.semibold))
-            ScrollView {
-                Text(appState.helperConsole.isEmpty ? "No helper output recorded yet." : appState.helperConsole)
-                    .font(.system(.caption, design: .monospaced))
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            }
-            .frame(minHeight: 180)
-            .padding(12)
-            .background(.quaternary, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
-        }
-    }
-
-    private func emptyState(_ message: String) -> some View {
-        Text(message)
-            .font(.callout)
-            .foregroundStyle(.secondary)
-            .padding(14)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(.quaternary, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
     }
 
     private var selectedRoom: ScrapedRoomsResponse.Room? {
@@ -402,17 +182,99 @@ struct DesktopDashboardView: View {
         return appState.tasks?.tasks.first(where: { $0.id == selectedTaskID })
     }
 
-    private func csvBinding(for keyPath: WritableKeyPath<ScrapePreferences, [String]>) -> Binding<String> {
-        Binding<String>(
-            get: {
-                appState.scrapePreferences[keyPath: keyPath].joined(separator: ", ")
-            },
-            set: { value in
-                appState.scrapePreferences[keyPath: keyPath] = value
-                    .split(separator: ",")
-                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-                    .filter { !$0.isEmpty }
-            }
+    private var currentSelection: DashboardSelection? {
+        if let selectedRoom {
+            return .room(selectedRoom)
+        }
+        if let selectedBooking {
+            return .booking(selectedBooking)
+        }
+        if let selectedTask {
+            return .task(selectedTask)
+        }
+        return nil
+    }
+
+    private var summaryColumns: [GridItem] {
+        [
+            GridItem(.adaptive(minimum: 220), spacing: 12)
+        ]
+    }
+
+    private var dashboardColumns: [GridItem] {
+        [
+            GridItem(.flexible(minimum: 320), spacing: 16),
+            GridItem(.flexible(minimum: 320), spacing: 16)
+        ]
+    }
+
+    private var scrapePreferencesBinding: Binding<ScrapePreferences> {
+        Binding(
+            get: { appState.scrapePreferences },
+            set: { appState.scrapePreferences = $0 }
         )
+    }
+
+    @ViewBuilder
+    private func heroPill(title: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title.uppercased())
+                .font(.caption2.weight(.bold))
+                .tracking(0.8)
+                .foregroundStyle(.white.opacity(0.78))
+
+            Text(value)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.white)
+                .lineLimit(1)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .background(.white.opacity(0.14), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+    }
+
+    @ViewBuilder
+    private func errorPanel(message: String) -> some View {
+        SagasuPanel(
+            title: "Helper warning",
+            subtitle: "The helper surfaced an error during the last refresh cycle.",
+            systemImage: "exclamationmark.triangle.fill"
+        ) {
+            Text(message)
+                .font(.callout)
+        }
+    }
+
+    private func refreshNow() {
+        appState.refresh(manual: true)
+    }
+
+    private func saveCredentials() {
+        appState.saveCredentials(email: email, password: password)
+        password = ""
+    }
+
+    private func clearCredentials() {
+        appState.clearCredentials()
+        email = ""
+        password = ""
+    }
+
+    private func selectRoom(_ id: String) {
+        selectedRoomID = id
+        selectedBookingID = nil
+        selectedTaskID = nil
+    }
+
+    private func selectBooking(_ id: String) {
+        selectedBookingID = id
+        selectedRoomID = nil
+        selectedTaskID = nil
+    }
+
+    private func selectTask(_ id: String) {
+        selectedTaskID = id
+        selectedRoomID = nil
+        selectedBookingID = nil
     }
 }

--- a/Sources/App/MenuBarLabelView.swift
+++ b/Sources/App/MenuBarLabelView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import SagasuShared
 
 struct MenuBarLabelView: View {
-    let appState: AppState
+    @ObservedObject var appState: AppState
 
     private var badgeText: String {
         if appState.isLoading {
@@ -20,18 +20,48 @@ struct MenuBarLabelView: View {
         return appState.authState.has_credentials ? "0" : "?"
     }
 
+    private var tint: Color {
+        if appState.isLoading {
+            return .orange
+        }
+
+        if appState.errorMessage != nil {
+            return .red
+        }
+
+        if appState.authState.has_credentials {
+            return SagasuTheme.brand
+        }
+
+        return .secondary
+    }
+
+    private var symbolName: String {
+        if appState.errorMessage != nil {
+            return "exclamationmark.triangle.fill"
+        }
+
+        if appState.isLoading {
+            return "arrow.clockwise.circle.fill"
+        }
+
+        return "building.2.crop.circle.fill"
+    }
+
     var body: some View {
         HStack(spacing: 6) {
-            Image(systemName: "building.2.crop.circle")
-                .font(.system(size: 13, weight: .medium))
+            Image(systemName: symbolName)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(tint)
 
             Text(badgeText)
                 .font(.system(size: 11, weight: .semibold, design: .rounded))
                 .monospacedDigit()
                 .padding(.horizontal, 5)
                 .padding(.vertical, 1)
-                .background(.quaternary, in: Capsule())
+                .background(tint.opacity(0.14), in: Capsule())
         }
+        .padding(.horizontal, 4)
         .accessibilityLabel(appState.menuBarTitle)
     }
 }

--- a/Sources/App/SagasuControlPanels.swift
+++ b/Sources/App/SagasuControlPanels.swift
@@ -1,0 +1,228 @@
+import SwiftUI
+import SagasuShared
+
+struct CredentialsPanel: View {
+    let title: String
+    let subtitle: String?
+    @Binding var email: String
+    @Binding var password: String
+    let onSave: () -> Void
+    let onClear: () -> Void
+
+    var body: some View {
+        SagasuPanel(
+            title: title,
+            subtitle: subtitle,
+            systemImage: "person.crop.circle.badge.key"
+        ) {
+            VStack(alignment: .leading, spacing: 12) {
+                TextField("SMU email", text: $email)
+                    .textFieldStyle(.roundedBorder)
+
+                SecureField("SMU password", text: $password)
+                    .textFieldStyle(.roundedBorder)
+
+                HStack(spacing: 10) {
+                    Button("Save to Keychain", action: onSave)
+                        .buttonStyle(.borderedProminent)
+
+                    Button("Clear Credentials", action: onClear)
+                        .buttonStyle(.bordered)
+                }
+            }
+        }
+    }
+}
+
+struct HelperControlsPanel: View {
+    let currentMode: HelperRunMode?
+    let currentDescription: String
+    let onStart: (HelperRunMode) -> Void
+    let onStop: () -> Void
+
+    var body: some View {
+        SagasuPanel(
+            title: "Helper control",
+            subtitle: "Start the helper directly for ad-hoc refreshes or XPC integration.",
+            systemImage: "cpu"
+        ) {
+            VStack(alignment: .leading, spacing: 14) {
+                SagasuStatusPill(
+                    title: "Mode",
+                    value: currentDescription,
+                    tint: currentMode == nil ? .secondary : SagasuTheme.brand
+                )
+
+                HStack(spacing: 10) {
+                    ForEach(HelperRunMode.allCases) { mode in
+                        helperButton(for: mode)
+                    }
+
+                    Button("Stop", action: onStop)
+                        .buttonStyle(.bordered)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func helperButton(for mode: HelperRunMode) -> some View {
+        if currentMode == mode {
+            Button("\(mode.title) Active") {
+                onStart(mode)
+            }
+            .buttonStyle(.borderedProminent)
+        } else {
+            Button("Start \(mode.title)") {
+                onStart(mode)
+            }
+            .buttonStyle(.bordered)
+        }
+    }
+}
+
+struct BackgroundServicePanel: View {
+    let status: HelperLaunchAgentStatus?
+    let summary: String
+    let showsPaths: Bool
+    let onInstall: () -> Void
+    let onStart: () -> Void
+    let onStop: () -> Void
+    let onRemove: () -> Void
+
+    var body: some View {
+        SagasuPanel(
+            title: "Background service",
+            subtitle: "Install a LaunchAgent when you want scheduled refreshes to keep local data current.",
+            systemImage: "clock.arrow.2.circlepath"
+        ) {
+            VStack(alignment: .leading, spacing: 14) {
+                SagasuStatusPill(
+                    title: "Launch agent",
+                    value: summary,
+                    tint: statusTint
+                )
+
+                if showsPaths, let status {
+                    VStack(alignment: .leading, spacing: 8) {
+                        pathRow(title: "Plist", value: status.plistURL.path)
+                        pathRow(title: "Log", value: status.logURL.path)
+
+                        if let helperURL = status.helperURL {
+                            pathRow(title: "Helper", value: helperURL.path)
+                        }
+                    }
+                }
+
+                LazyVGrid(columns: actionColumns, spacing: 10) {
+                    Button("Install", action: onInstall)
+                        .buttonStyle(.borderedProminent)
+
+                    Button("Start", action: onStart)
+                        .buttonStyle(.bordered)
+
+                    Button("Stop", action: onStop)
+                        .buttonStyle(.bordered)
+
+                    Button("Remove", action: onRemove)
+                        .buttonStyle(.bordered)
+                }
+            }
+        }
+    }
+
+    private var actionColumns: [GridItem] {
+        [
+            GridItem(.flexible(), spacing: 10),
+            GridItem(.flexible(), spacing: 10)
+        ]
+    }
+
+    private var statusTint: Color {
+        guard let status else { return .secondary }
+        if status.isLoaded {
+            return .green
+        }
+        if status.isInstalled {
+            return .yellow
+        }
+        return .secondary
+    }
+
+    @ViewBuilder
+    private func pathRow(title: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            Text(value)
+                .font(.system(.caption, design: .monospaced))
+                .textSelection(.enabled)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+struct ScrapePreferencesPanel: View {
+    @Binding var preferences: ScrapePreferences
+    let onSave: () -> Void
+
+    var body: some View {
+        SagasuPanel(
+            title: "Scrape preferences",
+            subtitle: "Tune the helper inputs that shape the next refresh payload.",
+            systemImage: "slider.horizontal.3"
+        ) {
+            VStack(alignment: .leading, spacing: 12) {
+                LazyVGrid(columns: columns, spacing: 10) {
+                    textField(title: "Date", text: $preferences.date, prompt: "TODAY")
+                    textField(title: "Start", text: $preferences.start_time, prompt: "08:00")
+                    textField(title: "End", text: $preferences.end_time, prompt: "22:00")
+                    textField(title: "Capacity", text: $preferences.capacity, prompt: "Optional")
+                }
+
+                textField(title: "Buildings", text: csvBinding(for: \.buildings), prompt: "Comma-separated")
+                textField(title: "Floors", text: csvBinding(for: \.floors), prompt: "Comma-separated")
+                textField(title: "Facility types", text: csvBinding(for: \.facility_types), prompt: "Comma-separated")
+                textField(title: "Equipment", text: csvBinding(for: \.equipment), prompt: "Comma-separated")
+
+                Button("Save preferences", action: onSave)
+                    .buttonStyle(.borderedProminent)
+            }
+        }
+    }
+
+    private var columns: [GridItem] {
+        [
+            GridItem(.flexible(), spacing: 10),
+            GridItem(.flexible(), spacing: 10)
+        ]
+    }
+
+    @ViewBuilder
+    private func textField(title: String, text: Binding<String>, prompt: String) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            TextField(prompt, text: text)
+                .textFieldStyle(.roundedBorder)
+        }
+    }
+
+    private func csvBinding(for keyPath: WritableKeyPath<ScrapePreferences, [String]>) -> Binding<String> {
+        Binding(
+            get: {
+                preferences[keyPath: keyPath].joined(separator: ", ")
+            },
+            set: { value in
+                preferences[keyPath: keyPath] = value
+                    .split(separator: ",")
+                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                    .filter { !$0.isEmpty }
+            }
+        )
+    }
+}

--- a/Sources/App/SagasuMenuBarApp.swift
+++ b/Sources/App/SagasuMenuBarApp.swift
@@ -9,6 +9,7 @@ struct SagasuMenuBarApp: App {
             DesktopDashboardView()
                 .environmentObject(appState)
         }
+        .defaultSize(width: 1180, height: 780)
 
         MenuBarExtra {
             ContentView()

--- a/Sources/App/SagasuUI.swift
+++ b/Sources/App/SagasuUI.swift
@@ -1,0 +1,283 @@
+import SwiftUI
+import SagasuShared
+
+enum SagasuTheme {
+    static let brand = Color(red: 0.08, green: 0.62, blue: 0.57)
+    static let brandSecondary = Color(red: 0.16, green: 0.40, blue: 0.84)
+    static let backgroundTop = Color(red: 0.96, green: 0.98, blue: 0.97)
+    static let backgroundBottom = Color(red: 0.91, green: 0.95, blue: 0.99)
+
+    static var heroGradient: LinearGradient {
+        LinearGradient(
+            colors: [
+                brand,
+                brandSecondary
+            ],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+
+    static var pageGradient: LinearGradient {
+        LinearGradient(
+            colors: [
+                backgroundTop,
+                backgroundBottom
+            ],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+
+    static func stateColor(for state: DatasetState) -> Color {
+        switch state {
+        case .idle:
+            return .secondary
+        case .loading:
+            return .orange
+        case .success:
+            return .green
+        case .stale:
+            return .yellow
+        case .failed:
+            return .red
+        }
+    }
+}
+
+struct SagasuScreenBackground: View {
+    var body: some View {
+        SagasuTheme.pageGradient
+            .overlay(alignment: .topTrailing) {
+                Circle()
+                    .fill(SagasuTheme.brand.opacity(0.16))
+                    .frame(width: 280, height: 280)
+                    .blur(radius: 18)
+                    .offset(x: 96, y: -72)
+            }
+            .overlay(alignment: .bottomLeading) {
+                Circle()
+                    .fill(SagasuTheme.brandSecondary.opacity(0.12))
+                    .frame(width: 320, height: 320)
+                    .blur(radius: 24)
+                    .offset(x: -120, y: 100)
+            }
+            .ignoresSafeArea()
+    }
+}
+
+struct SagasuHeroBanner<Content: View>: View {
+    let eyebrow: String
+    let title: String
+    let subtitle: String
+    let systemImage: String
+    private let content: Content
+
+    init(
+        eyebrow: String,
+        title: String,
+        subtitle: String,
+        systemImage: String,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.eyebrow = eyebrow
+        self.title = title
+        self.subtitle = subtitle
+        self.systemImage = systemImage
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            HStack(alignment: .top, spacing: 16) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(eyebrow.uppercased())
+                        .font(.caption.weight(.bold))
+                        .tracking(1.4)
+                        .foregroundStyle(.white.opacity(0.82))
+
+                    Text(title)
+                        .font(.system(size: 30, weight: .bold, design: .rounded))
+                        .foregroundStyle(.white)
+
+                    Text(subtitle)
+                        .font(.body)
+                        .foregroundStyle(.white.opacity(0.88))
+                }
+
+                Spacer(minLength: 0)
+
+                Image(systemName: systemImage)
+                    .font(.system(size: 30, weight: .bold))
+                    .foregroundStyle(.white)
+                    .padding(14)
+                    .background(.white.opacity(0.14), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+            }
+
+            content
+        }
+        .padding(20)
+        .background(
+            SagasuTheme.heroGradient,
+            in: RoundedRectangle(cornerRadius: 28, style: .continuous)
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: 28, style: .continuous)
+                .strokeBorder(.white.opacity(0.16), lineWidth: 1)
+        }
+        .shadow(color: .black.opacity(0.12), radius: 22, x: 0, y: 16)
+    }
+}
+
+struct SagasuPanel<Content: View>: View {
+    let title: String
+    let subtitle: String?
+    let systemImage: String
+    private let content: Content
+
+    init(
+        title: String,
+        subtitle: String? = nil,
+        systemImage: String,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.title = title
+        self.subtitle = subtitle
+        self.systemImage = systemImage
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: systemImage)
+                    .font(.headline)
+                    .foregroundStyle(SagasuTheme.brand)
+                    .frame(width: 34, height: 34)
+                    .background(SagasuTheme.brand.opacity(0.12), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
+                        .font(.headline)
+
+                    if let subtitle {
+                        Text(subtitle)
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Spacer(minLength: 0)
+            }
+
+            content
+        }
+        .padding(18)
+        .background {
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(.regularMaterial)
+                .overlay {
+                    RoundedRectangle(cornerRadius: 24, style: .continuous)
+                        .strokeBorder(.white.opacity(0.45), lineWidth: 1)
+                }
+        }
+        .shadow(color: .black.opacity(0.06), radius: 18, x: 0, y: 10)
+    }
+}
+
+struct SagasuMetricCard: View {
+    let title: String
+    let value: String
+    let detail: String?
+    let systemImage: String
+    let tint: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Image(systemName: systemImage)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(tint)
+
+                Spacer(minLength: 0)
+
+                Text(title)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+
+            Text(value)
+                .font(.system(size: 26, weight: .bold, design: .rounded))
+                .monospacedDigit()
+
+            if let detail {
+                Text(detail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(tint.opacity(0.10))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                        .strokeBorder(tint.opacity(0.14), lineWidth: 1)
+                }
+        )
+    }
+}
+
+struct SagasuStatusPill: View {
+    let title: String
+    let value: String
+    let tint: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title.uppercased())
+                .font(.caption2.weight(.bold))
+                .tracking(1)
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(tint)
+                    .frame(width: 8, height: 8)
+
+                Text(value)
+                    .font(.caption.weight(.semibold))
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(tint.opacity(0.12))
+        )
+    }
+}
+
+struct SagasuEmptyStateCard: View {
+    let title: String
+    let message: String
+    let systemImage: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label(title, systemImage: systemImage)
+                .font(.headline)
+
+            Text(message)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(.quaternary.opacity(0.7))
+        )
+    }
+}


### PR DESCRIPTION
## What changed
- refactored the macOS menu bar and desktop dashboard into smaller SwiftUI panels and reusable shared UI components
- introduced a small visual system for cards, hero banners, status pills, and empty states
- updated the menu bar label state observation and set a more appropriate default dashboard window size

## Why
- the existing SwiftUI surfaces had grown into large view files with repeated panels and inline actions
- this keeps the same helper-driven behavior while aligning the app more closely with SwiftUI composition conventions
- the refreshed UI gives the desktop app clearer hierarchy and more intentional presentation without changing the underlying data flow

## Impact
- no helper/core logic changes
- source-only UI refactor across `Sources/App`
- local validation covered test, app-bundle, and DMG packaging paths

## Validation
- `swift test`
- `./scripts/build.sh`
- `./scripts/build_app_bundle.sh`
- `./scripts/package_dmg.sh`
